### PR TITLE
Consolidate split & rejoin for efficiency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,7 +283,6 @@ dependencies = [
  "enum_delegate",
  "heck 0.5.0",
  "iai-callgrind",
- "ndarray",
  "num-complex",
  "palette",
  "png",
@@ -1966,16 +1965,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
-name = "matrixmultiply"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7574c1cf36da4798ab73da5b215bbf444f50718207754cb522201d78d1cd0ff2"
-dependencies = [
- "autocfg",
- "rawpointer",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2004,19 +1993,6 @@ checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
  "simd-adler32",
-]
-
-[[package]]
-name = "ndarray"
-version = "0.15.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
-dependencies = [
- "matrixmultiply",
- "num-complex",
- "num-integer",
- "num-traits",
- "rawpointer",
 ]
 
 [[package]]
@@ -2093,16 +2069,6 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
 
 [[package]]
 name = "num-traits"
@@ -2681,12 +2647,6 @@ name = "raw-window-handle"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
-
-[[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"

--- a/cli/src/plot.rs
+++ b/cli/src/plot.rs
@@ -4,7 +4,7 @@
 use std::time::SystemTime;
 
 use brot3_engine::colouring;
-use brot3_engine::fractal::{self, Algorithm, Point, Scalar, Size, SplitMethod, Tile, TileSpec};
+use brot3_engine::fractal::{self, Algorithm, Point, Scalar, Size, Tile, TileSpec};
 use brot3_engine::render::{self, autodetect_extension, Renderer};
 use brot3_engine::util::Rect;
 
@@ -223,7 +223,7 @@ pub(crate) fn plot(args: &Args, debug: u8) -> anyhow::Result<()> {
     let splits: Vec<TileSpec> = if args.no_split {
         vec![spec]
     } else {
-        spec.split(SplitMethod::RowsOfHeight(50), debug)?
+        spec.split(50, debug)?
     };
     let mut tiles: Vec<Tile> = splits.iter().map(|ts| Tile::new(ts, debug)).collect();
     let time1 = SystemTime::now();

--- a/cli/src/plot.rs
+++ b/cli/src/plot.rs
@@ -231,18 +231,15 @@ pub(crate) fn plot(args: &Args, debug: u8) -> anyhow::Result<()> {
         .par_iter_mut()
         .for_each(brot3_engine::fractal::Tile::plot);
     let time2 = SystemTime::now();
-    let time3 = SystemTime::now();
 
-    println!("{spec}");
     let result = renderer.render_file(&args.output_filename, &spec, &tiles, colourer);
-    let time4 = SystemTime::now();
+    let time3 = SystemTime::now();
     if args.show_timing {
         println!(
-            "times: prepare {:?}, plot {:?}, join {:?}, render {:?}",
+            "times: prepare {:?}, plot {:?} render {:?}",
             time1.duration_since(time0).unwrap_or_default(),
             time2.duration_since(time1).unwrap_or_default(),
             time3.duration_since(time2).unwrap_or_default(),
-            time4.duration_since(time3).unwrap_or_default(),
         );
     }
     result

--- a/cli/src/plot.rs
+++ b/cli/src/plot.rs
@@ -231,16 +231,10 @@ pub(crate) fn plot(args: &Args, debug: u8) -> anyhow::Result<()> {
         .par_iter_mut()
         .for_each(brot3_engine::fractal::Tile::plot);
     let time2 = SystemTime::now();
-    let tile: Tile = if args.no_split {
-        tiles.remove(0)
-    } else {
-        Tile::join(&spec, &mut tiles)?
-    };
     let time3 = SystemTime::now();
 
-    println!("{}", tile.spec);
-    let temp = vec![tile];
-    let result = renderer.render_file(&args.output_filename, &spec, &temp, colourer);
+    println!("{spec}");
+    let result = renderer.render_file(&args.output_filename, &spec, &tiles, colourer);
     let time4 = SystemTime::now();
     if args.show_timing {
         println!(

--- a/cli/src/plot.rs
+++ b/cli/src/plot.rs
@@ -238,7 +238,9 @@ pub(crate) fn plot(args: &Args, debug: u8) -> anyhow::Result<()> {
     };
     let time3 = SystemTime::now();
 
-    let result = renderer.render_file(&args.output_filename, &tile, colourer);
+    println!("{}", tile.spec);
+    let temp = vec![tile];
+    let result = renderer.render_file(&args.output_filename, &spec, &temp, colourer);
     let time4 = SystemTime::now();
     if args.show_timing {
         println!(
@@ -249,7 +251,6 @@ pub(crate) fn plot(args: &Args, debug: u8) -> anyhow::Result<()> {
             time4.duration_since(time3).unwrap_or_default(),
         );
     }
-    println!("{}", tile.spec);
     result
 }
 

--- a/cli/src/plot.rs
+++ b/cli/src/plot.rs
@@ -235,7 +235,11 @@ pub(crate) fn plot(args: &Args, debug: u8) -> anyhow::Result<()> {
     } else {
         spec.split(args.strip_size, debug)?
     };
-    let mut tiles: Vec<Tile> = splits.iter().map(|ts| Tile::new(ts, debug)).collect();
+    let mut tiles: Vec<Tile> = Vec::new();
+    splits
+        .par_iter()
+        .map(|ts| Tile::new(ts, debug))
+        .collect_into_vec(&mut tiles);
     let time1 = SystemTime::now();
     tiles
         .par_iter_mut()

--- a/cli/src/plot.rs
+++ b/cli/src/plot.rs
@@ -234,7 +234,7 @@ pub(crate) fn plot(args: &Args, debug: u8) -> anyhow::Result<()> {
     let tile: Tile = if args.no_split {
         tiles.remove(0)
     } else {
-        Tile::join(&spec, &tiles)?
+        Tile::join(&spec, &mut tiles)?
     };
     let time3 = SystemTime::now();
 

--- a/cli/src/plot.rs
+++ b/cli/src/plot.rs
@@ -169,6 +169,16 @@ pub(crate) struct Args {
     /// Measures and outputs the time to complete various parts of the process.
     #[arg(long, display_order(900), help_heading("Developer options"))]
     pub(crate) show_timing: bool,
+
+    /// The number of rows per render strip
+    #[arg(
+        long,
+        display_order(900),
+        help_heading("Developer options"),
+        default_value = "10",
+        value_name = "PIXELS"
+    )]
+    pub(crate) strip_size: u32,
 }
 
 fn check_fix_axes(input: Point) -> anyhow::Result<Point> {
@@ -223,7 +233,7 @@ pub(crate) fn plot(args: &Args, debug: u8) -> anyhow::Result<()> {
     let splits: Vec<TileSpec> = if args.no_split {
         vec![spec.clone()]
     } else {
-        spec.split(50, debug)?
+        spec.split(args.strip_size, debug)?
     };
     let mut tiles: Vec<Tile> = splits.iter().map(|ts| Tile::new(ts, debug)).collect();
     let time1 = SystemTime::now();

--- a/cli/src/plot.rs
+++ b/cli/src/plot.rs
@@ -221,7 +221,7 @@ pub(crate) fn plot(args: &Args, debug: u8) -> anyhow::Result<()> {
 
     let time0 = SystemTime::now();
     let splits: Vec<TileSpec> = if args.no_split {
-        vec![spec]
+        vec![spec.clone()]
     } else {
         spec.split(50, debug)?
     };

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -16,7 +16,6 @@ anyhow = { workspace = true }
 clap = { workspace = true, features = ["wrap_help", "derive"] }
 enum_delegate = "0.2.0"
 heck = "0.5.0"
-ndarray = "0.15.6"
 num-complex = "0.4.5"
 palette = "0.7.5"
 png = { workspace = true }

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -19,6 +19,7 @@ heck = "0.5.0"
 num-complex = "0.4.5"
 palette = "0.7.5"
 png = { workspace = true }
+rayon = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 

--- a/engine/benches/engine.rs
+++ b/engine/benches/engine.rs
@@ -12,7 +12,6 @@ use brot3_engine::{
 };
 
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
-use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
 
 // //////////////////////////////////////////////////////////////////////////////////////////
 // FRACTALS
@@ -113,23 +112,5 @@ fn colour_tile(c: &mut Criterion) {
 criterion_group!(colourers, colour_pixel, colour_tile);
 
 // //////////////////////////////////////////////////////////////////////////////////////////
-// TILE OPERATIONS
 
-fn tile_join(c: &mut Criterion) {
-    // prepare and iterate on a bunch of tiles; we only care about the joining
-    let mut group = c.benchmark_group("tiles");
-    let single = get_test_tile_spec(fractal::Selection::Original, 1000);
-    let specs = single.split(10, 0).unwrap();
-    let mut tiles: Vec<_> = specs.iter().map(|ts| Tile::new(ts, 0)).collect();
-    tiles.par_iter_mut().for_each(|t| black_box(t).plot());
-
-    let _ = group.bench_function("join", |b| {
-        b.iter(|| Tile::join(&single, black_box(&mut tiles)).unwrap());
-    });
-}
-
-criterion_group!(tiles, tile_join);
-
-// //////////////////////////////////////////////////////////////////////////////////////////
-
-criterion_main!(fractals, colourers, tiles);
+criterion_main!(fractals, colourers);

--- a/engine/benches/engine.rs
+++ b/engine/benches/engine.rs
@@ -6,7 +6,7 @@
 #[allow(clippy::enum_glob_use)]
 use brot3_engine::{
     colouring::{self, Instance, OutputsRgb8, Selection::*},
-    fractal::{self, Algorithm, Location, Point, PointData, Size, SplitMethod, Tile, TileSpec},
+    fractal::{self, Algorithm, Location, Point, PointData, Size, Tile, TileSpec},
     render::Png,
     util::Rect,
 };
@@ -119,7 +119,7 @@ fn tile_join(c: &mut Criterion) {
     // prepare and iterate on a bunch of tiles; we only care about the joining
     let mut group = c.benchmark_group("tiles");
     let single = get_test_tile_spec(fractal::Selection::Original, 1000);
-    let specs = single.split(SplitMethod::RowsOfHeight(50), 0).unwrap();
+    let specs = single.split(10, 0).unwrap();
     let mut tiles: Vec<_> = specs.iter().map(|ts| Tile::new(ts, 0)).collect();
     tiles.par_iter_mut().for_each(|t| black_box(t).plot());
 

--- a/engine/benches/engine.rs
+++ b/engine/benches/engine.rs
@@ -124,7 +124,7 @@ fn tile_join(c: &mut Criterion) {
     tiles.par_iter_mut().for_each(|t| black_box(t).plot());
 
     let _ = group.bench_function("join", |b| {
-        b.iter(|| Tile::join(&single, black_box(&tiles)).unwrap());
+        b.iter(|| Tile::join(&single, black_box(&mut tiles)).unwrap());
     });
 }
 

--- a/engine/src/fractal.rs
+++ b/engine/src/fractal.rs
@@ -17,7 +17,7 @@ pub use framework::{decode, factory, Algorithm, Instance, Selection};
 pub use maths::{Point, Scalar};
 pub use pointdata::PointData;
 pub use tile::Tile;
-pub use tilespec::{SplitMethod, TileSpec};
+pub use tilespec::TileSpec;
 
 /// The user is allowed to specify the plot location in multiple ways.
 #[derive(Debug, Clone, Copy)]

--- a/engine/src/fractal/tile.rs
+++ b/engine/src/fractal/tile.rs
@@ -151,7 +151,7 @@ impl fmt::Display for Tile {
 mod tests {
     use crate::{
         colouring::{self, testing::White},
-        fractal::{self, framework::Zero, tilespec::SplitMethod, Location, Point, Size, TileSpec},
+        fractal::{self, framework::Zero, Location, Point, Size, TileSpec},
         util::Rect,
     };
 
@@ -175,7 +175,7 @@ mod tests {
             256,
             WHITE,
         );
-        let split = spec.split(SplitMethod::RowsOfHeight(10), 0);
+        let split = spec.split(10, 0);
         let mut tiles: Vec<Tile> = split.unwrap().iter().map(|ts| Tile::new(ts, 0)).collect();
         for t in &mut tiles {
             t.plot();

--- a/engine/src/fractal/tile.rs
+++ b/engine/src/fractal/tile.rs
@@ -35,13 +35,14 @@ impl Tile {
 
     /// Internal constructor used by `new()` and `join()`
     fn new_internal(spec: &TileSpec, debug: u8) -> Self {
+        let offset = spec.y_offset().map(|y| Rect::<u32>::new(0, y));
         Self {
             debug,
             // Data for this tile.
             point_data: Array2::default((spec.height() as usize, spec.width() as usize)),
             max_iter_plotted: 0,
             spec: spec.clone(),
-            offset_within_plot: spec.offset_within_plot(),
+            offset_within_plot: offset,
         }
     }
 

--- a/engine/src/fractal/tile.rs
+++ b/engine/src/fractal/tile.rs
@@ -20,8 +20,6 @@ pub struct Tile {
     pub max_iter_plotted: u32,
     /// Specification of this plot
     pub spec: TileSpec,
-    /// The algorithm to use
-    algorithm: super::Instance,
     /// If present, this tile is part of a larger plot; this is its location offset (X,Y) in pixels, relative to the TOP LEFT of the plot.
     offset_within_plot: Option<Rect<u32>>,
 }
@@ -43,7 +41,6 @@ impl Tile {
             point_data: Array2::default((spec.height() as usize, spec.width() as usize)),
             max_iter_plotted: 0,
             spec: spec.clone(),
-            algorithm: *spec.algorithm(),
             offset_within_plot: spec.offset_within_plot(),
         }
     }
@@ -101,7 +98,7 @@ impl Tile {
             if debug > 1 {
                 println!("point {x},{y} => {}", point.origin);
             }
-            self.algorithm.prepare(point);
+            self.spec.algorithm().prepare(point);
         }
         // TODO: live_pixel count
     }
@@ -111,7 +108,7 @@ impl Tile {
         let max_iter = self.spec.max_iter_requested();
         for p in &mut self.point_data {
             if p.result.is_none() {
-                self.algorithm.pixel(p, max_iter);
+                self.spec.algorithm().pixel(p, max_iter);
             }
         }
         self.max_iter_plotted = max_iter;

--- a/engine/src/fractal/tile.rs
+++ b/engine/src/fractal/tile.rs
@@ -18,7 +18,7 @@ pub struct Tile {
     /// Specification of this plot
     pub spec: TileSpec,
     /// If present, this tile is a strip of a larger plot; this is its Y offset in pixels, relative to the TOP LEFT of the plot.
-    y_offset: Option<u32>,
+    pub y_offset: Option<u32>,
 }
 
 impl Tile {

--- a/engine/src/fractal/tile.rs
+++ b/engine/src/fractal/tile.rs
@@ -1,9 +1,8 @@
 // (c) 2024 Ross Younger
 
-use super::{Algorithm, Point, PointData, Scalar, TileSpec};
+use super::{Algorithm, Point, PointData, TileSpec};
 
-use anyhow::{anyhow, ensure, Context};
-use ndarray::Array2;
+use anyhow::ensure;
 use num_complex::ComplexFloat;
 use std::{cmp::max, fmt};
 
@@ -14,7 +13,7 @@ pub struct Tile {
     debug: u8,
     /// Working data. Address as [(row,column)] aka (y,x).
     /// <div class="warning">CAUTION: This array is TOP LEFT oriented. The first row is the top row, not the Origin row.</div>
-    point_data: ndarray::Array2<PointData>,
+    point_data: Vec<PointData>,
     /// Max iterations we plotted to
     pub max_iter_plotted: u32,
     /// Specification of this plot
@@ -37,7 +36,7 @@ impl Tile {
         Self {
             debug,
             // Data for this tile.
-            point_data: Array2::default((spec.height() as usize, spec.width() as usize)),
+            point_data: Vec::with_capacity((spec.height() * spec.width()) as usize),
             max_iter_plotted: 0,
             spec: spec.clone(),
             y_offset: spec.y_offset(),
@@ -45,24 +44,18 @@ impl Tile {
     }
 
     /// Quasi-constructor: Reassembles the tiles of a split plot into a single plot
-    pub fn join(spec: &TileSpec, tiles: &Vec<Tile>) -> anyhow::Result<Tile> {
+    /// N.B. Data is stolen from the passed-in tiles!
+    pub fn join(spec: &TileSpec, tiles: &mut Vec<Tile>) -> anyhow::Result<Tile> {
         ensure!(!tiles.is_empty(), "No tiles given to join");
         // TODO: Might be nice if we could ensure that all data points were covered i.e. no tiles are missing...
 
         let mut result = Tile::new_internal(spec, 0);
         result.max_iter_plotted = tiles.iter().fold(0, |b, t| max(b, t.max_iter_plotted));
 
+        // Tiles need to be sorted by offset
+        tiles.sort_by(|a, b| a.y_offset.unwrap_or(0).cmp(&b.y_offset.unwrap_or(0)));
         for t in tiles {
-            let offset = t
-                .y_offset
-                .ok_or_else(|| anyhow!("joining subtile did not contain offset"))
-                .with_context(|| format!("{t:?}"))?;
-
-            let mut dest = result.point_data.slice_mut(ndarray::s![
-                offset as usize..(offset + t.spec.height()) as usize,
-                ..
-            ]);
-            dest.assign(&t.point_data);
+            result.point_data.append(&mut t.point_data);
         }
         Ok(result)
     }
@@ -88,18 +81,23 @@ impl Tile {
             );
         }
 
-        for ((y, x), point) in self.point_data.indexed_iter_mut() {
-            point.origin = origin_pixel
-                + Point {
-                    re: x as Scalar * step.re,
-                    im: y as Scalar * -step.im, // note '-' as we are stepping down the imaginary dimension
-                };
-            if debug > 1 {
-                println!("point {x},{y} => {}", point.origin);
-            }
-            self.spec.algorithm().prepare(point);
+        for y in 0..self.spec.height() {
+            let im = f64::from(y) * -step.im; // note '-' as we are stepping down the imaginary dimension
+
+            // For each pixel in width...
+            let points = (0..self.spec.width())
+                // compute real coordinate
+                .map(|x| f64::from(x) * step.re)
+                // compute pixel
+                .map(|re| origin_pixel + Point { re, im })
+                // assemble and prepare point data
+                .map(|or| {
+                    let mut pd = PointData::new(or);
+                    self.spec.algorithm().prepare(&mut pd);
+                    pd
+                });
+            self.point_data.extend(points);
         }
-        // TODO: live_pixel count
     }
 
     /// Runs the fractal iteration for all points in this tile
@@ -117,7 +115,7 @@ impl Tile {
     /// Result accessor
     /// <div class="warning">CAUTION: This array is TOP LEFT oriented. The first row is the top row, not the Origin (bottom) row!</div>
     #[must_use]
-    pub fn result(&self) -> &Array2<PointData> {
+    pub fn result(&self) -> &Vec<PointData> {
         &self.point_data
     }
 }
@@ -125,11 +123,13 @@ impl Tile {
 /// CSV format output
 impl fmt::Display for Tile {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let width = self.spec.width() as usize;
         for y in 0..self.spec.height() as usize {
-            self.point_data[(y, 0)].fmt(f, self.debug)?;
-            for x in 1..self.spec.width() as usize {
+            // SOMEDAY: Rewrite this as a map operation. But it may not be worth it.
+            self.point_data[y * width].fmt(f, self.debug)?;
+            for x in 1..width {
                 write!(f, ",")?;
-                self.point_data[(y, x)].fmt(f, self.debug)?;
+                self.point_data[y * width + x].fmt(f, self.debug)?;
             }
             writeln!(f)?;
         }
@@ -170,9 +170,8 @@ mod tests {
         for t in &mut tiles {
             t.plot();
         }
-        let result = Tile::join(&spec, &tiles).unwrap();
+        let result = Tile::join(&spec, &mut tiles).unwrap();
         let data = result.result();
-        assert_eq!(data.nrows(), spec.height() as usize);
-        assert_eq!(data.ncols(), spec.width() as usize);
+        assert_eq!(data.len(), (spec.height() * spec.width()) as usize);
     }
 }

--- a/engine/src/fractal/tile.rs
+++ b/engine/src/fractal/tile.rs
@@ -42,8 +42,8 @@ impl Tile {
             // Data for this tile.
             point_data: Array2::default((spec.height() as usize, spec.width() as usize)),
             max_iter_plotted: 0,
-            spec: *spec,
-            algorithm: spec.algorithm(),
+            spec: spec.clone(),
+            algorithm: *spec.algorithm(),
             offset_within_plot: spec.offset_within_plot(),
         }
     }

--- a/engine/src/render/ascii.rs
+++ b/engine/src/render/ascii.rs
@@ -17,6 +17,7 @@ impl Renderer for Csv {
         tiles: &[Tile],
         _: Instance,
     ) -> anyhow::Result<()> {
+        anyhow::ensure!(self.check_ordering(tiles), "Tiles out of order");
         let mut output = Filename::open_for_writing(filename)?;
         for t in tiles {
             output.write_all(t.to_string().as_bytes())?;
@@ -40,6 +41,7 @@ impl Renderer for AsciiArt {
         tiles: &[Tile],
         _: Instance,
     ) -> anyhow::Result<()> {
+        anyhow::ensure!(self.check_ordering(tiles), "Tiles out of order");
         let mut output = Filename::open_for_writing(filename)?;
         // Preprocess: Find the range of output levels, discounting INF.
         let iter = tiles

--- a/engine/src/render/ascii.rs
+++ b/engine/src/render/ascii.rs
@@ -43,7 +43,13 @@ impl Renderer for AsciiArt {
         #[allow(clippy::cast_precision_loss)] // this is a quick & dirty output module
         let step = range / (n_levels - 1) as f32;
 
-        for row in data.outer_iter() {
+        for y in 0..tile.spec.height() as usize {
+            let start = y * tile.spec.width() as usize;
+            let end = (y + 1) * tile.spec.width() as usize;
+            let row = data
+                .get(start..end)
+                .expect("failed to slice row");
+            //assert_eq!(row.len(), tile.spec.width() as usize);
             let mut rowstr = row
                 .iter()
                 .map(PointData::iterations)

--- a/engine/src/render/ascii.rs
+++ b/engine/src/render/ascii.rs
@@ -2,7 +2,7 @@
 // (c) 2024 Ross Younger
 use super::Renderer;
 use crate::colouring::Instance;
-use crate::fractal::{PointData, Tile};
+use crate::fractal::{PointData, Tile, TileSpec};
 use crate::util::filename::Filename;
 
 /// CSV format, fractal points
@@ -10,8 +10,17 @@ use crate::util::filename::Filename;
 pub struct Csv {}
 
 impl Renderer for Csv {
-    fn render_file(&self, filename: &str, tile: &Tile, _: Instance) -> anyhow::Result<()> {
-        Filename::open_for_writing(filename)?.write_all(tile.to_string().as_bytes())?;
+    fn render_file(
+        &self,
+        filename: &str,
+        _: &TileSpec,
+        tiles: &[Tile],
+        _: Instance,
+    ) -> anyhow::Result<()> {
+        let mut output = Filename::open_for_writing(filename)?;
+        for t in tiles {
+            output.write_all(t.to_string().as_bytes())?;
+        }
         Ok(())
     }
 }
@@ -24,18 +33,37 @@ pub struct AsciiArt {}
 const DEFAULT_ASCII_ART_CHARSET: &[u8] = " .,:obOB%#".as_bytes();
 
 impl Renderer for AsciiArt {
-    fn render_file(&self, filename: &str, tile: &Tile, _: Instance) -> anyhow::Result<()> {
+    fn render_file(
+        &self,
+        filename: &str,
+        _: &TileSpec,
+        tiles: &[Tile],
+        _: Instance,
+    ) -> anyhow::Result<()> {
         let mut output = Filename::open_for_writing(filename)?;
-
-        // Find the range of output levels, discounting INF.
-        let data = tile.result();
-        let iter = data
+        // Preprocess: Find the range of output levels, discounting INF.
+        let iter = tiles
             .iter()
+            .flat_map(Tile::result)
             .map(PointData::iterations)
             .filter(|iters| iters.is_finite());
         let most = iter.clone().reduce(f32::max).unwrap();
         let least = iter.reduce(f32::min).unwrap();
 
+        for tile in tiles {
+            AsciiArt::render_tile(&mut output, tile, most, least)?;
+        }
+        Ok(())
+    }
+}
+
+impl AsciiArt {
+    fn render_tile(
+        output: &mut Box<dyn std::io::Write>,
+        tile: &Tile,
+        most: f32,
+        least: f32,
+    ) -> anyhow::Result<()> {
         // Map the output levels to a set of characters
         let n_levels = DEFAULT_ASCII_ART_CHARSET.len();
         let range = most - least;
@@ -46,9 +74,7 @@ impl Renderer for AsciiArt {
         for y in 0..tile.spec.height() as usize {
             let start = y * tile.spec.width() as usize;
             let end = (y + 1) * tile.spec.width() as usize;
-            let row = data
-                .get(start..end)
-                .expect("failed to slice row");
+            let row = tile.result().get(start..end).expect("failed to slice row");
             //assert_eq!(row.len(), tile.spec.width() as usize);
             let mut rowstr = row
                 .iter()

--- a/engine/src/render/framework.rs
+++ b/engine/src/render/framework.rs
@@ -4,7 +4,7 @@
 use std::ffi::OsStr;
 
 use crate::colouring::Instance;
-use crate::fractal::Tile;
+use crate::fractal::{Tile, TileSpec};
 
 use anyhow;
 use strum_macros::{Display, EnumDiscriminants, EnumMessage, FromRepr, IntoStaticStr};
@@ -49,8 +49,15 @@ impl crate::util::listable::Listable for Selection {}
 /// The trait knows nothing about output or buffering; the implementation is responsible for setting that up.
 #[enum_delegate::register]
 pub trait Renderer {
-    /// Renders fractal data and sends it to its output
-    fn render_file(&self, filename: &str, data: &Tile, colourer: Instance) -> anyhow::Result<()>;
+    /// Renders fractal data and sends it to its output.
+    /// Data tiles must be in correct order for output (they are generated in order, so this should be no imposition)
+    fn render_file(
+        &self,
+        filename: &str,
+        spec: &TileSpec,
+        data: &[Tile],
+        colourer: Instance,
+    ) -> anyhow::Result<()>;
 }
 
 /// Factory method for renderers

--- a/engine/src/render/framework.rs
+++ b/engine/src/render/framework.rs
@@ -58,6 +58,13 @@ pub trait Renderer {
         data: &[Tile],
         colourer: Instance,
     ) -> anyhow::Result<()>;
+
+    /// A sanity check that the input tiles are in the correct order
+    fn check_ordering(&self, tiles: &[Tile]) -> bool {
+        tiles
+            .windows(2)
+            .all(|w| w[0].y_offset.unwrap_or(0) < w[1].y_offset.unwrap_or(0))
+    }
 }
 
 /// Factory method for renderers

--- a/engine/src/render/png.rs
+++ b/engine/src/render/png.rs
@@ -80,6 +80,7 @@ impl Renderer for Png {
         tiles: &[Tile],
         colourer: Instance,
     ) -> anyhow::Result<()> {
+        anyhow::ensure!(self.check_ordering(tiles), "Tiles out of order");
         let handle = Filename::open_for_writing(filename)?;
         let bw = Box::new(BufWriter::new(handle));
         Png::render_png(spec, tiles, colourer, bw).with_context(|| "Failed to render PNG")?;

--- a/engine/src/render/png.rs
+++ b/engine/src/render/png.rs
@@ -3,7 +3,7 @@
 
 use super::Renderer;
 use crate::colouring::{Instance, OutputsRgb8};
-use crate::fractal::Tile;
+use crate::fractal::{Tile, TileSpec};
 use crate::util::filename::Filename;
 
 use anyhow::{Context, Result};
@@ -44,13 +44,18 @@ impl Png {
         image_data
     }
 
-    fn render_png(tile: &Tile, colourer: Instance, writer: Box<dyn std::io::Write>) -> Result<()> {
-        let mut encoder = png::Encoder::new(writer, tile.spec.width(), tile.spec.height());
+    fn render_png(
+        spec: &TileSpec,
+        tiles: &[Tile],
+        colourer: Instance,
+        writer: Box<dyn std::io::Write>,
+    ) -> Result<()> {
+        let mut encoder = png::Encoder::new(writer, spec.width(), spec.height());
         encoder.set_color(png::ColorType::Rgba);
         encoder.set_depth(png::BitDepth::Eight);
 
         encoder.add_text_chunk("software".to_string(), "brot3".to_string())?;
-        let info = tile.spec.to_string();
+        let info = spec.to_string();
         encoder.add_text_chunk("comment".to_string(), info)?;
 
         // MAYBE: allow user to specify gamma of their monitor?
@@ -58,17 +63,26 @@ impl Png {
         // MAYBE: set source chromaticities?
 
         let mut png_writer = encoder.write_header()?;
-        let image_data = Self::render_rgba(tile, colourer);
+        let image_data = tiles
+            .iter()
+            .flat_map(|t| Self::render_rgba(t, colourer))
+            .collect::<Vec<u8>>();
         png_writer.write_image_data(&image_data)?;
         Ok(())
     }
 }
 
 impl Renderer for Png {
-    fn render_file(&self, filename: &str, tile: &Tile, colourer: Instance) -> anyhow::Result<()> {
+    fn render_file(
+        &self,
+        filename: &str,
+        spec: &TileSpec,
+        tiles: &[Tile],
+        colourer: Instance,
+    ) -> anyhow::Result<()> {
         let handle = Filename::open_for_writing(filename)?;
         let bw = Box::new(BufWriter::new(handle));
-        Png::render_png(tile, colourer, bw).with_context(|| "Failed to render PNG")?;
+        Png::render_png(spec, tiles, colourer, bw).with_context(|| "Failed to render PNG")?;
         // You can test this error pathway by trying to write to /dev/full
         Ok(())
     }

--- a/engine/src/render/png.rs
+++ b/engine/src/render/png.rs
@@ -8,6 +8,7 @@ use crate::util::filename::Filename;
 
 use anyhow::{Context, Result};
 use palette::Srgb;
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use std::io::BufWriter;
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -64,7 +65,7 @@ impl Png {
 
         let mut png_writer = encoder.write_header()?;
         let image_data = tiles
-            .iter()
+            .par_iter()
             .flat_map(|t| Self::render_rgba(t, colourer))
             .collect::<Vec<u8>>();
         png_writer.write_image_data(&image_data)?;

--- a/ui/src-tauri/src/save_image.rs
+++ b/ui/src-tauri/src/save_image.rs
@@ -122,9 +122,7 @@ fn do_save_inner(
     tiles.par_iter_mut().for_each(|t| t.plot());
     // SOMEDAY: Consider progress reporting
     let time2 = SystemTime::now();
-    let plot = Tile::join(spec, &mut tiles)?;
-    let temp = vec![plot];
-    let result = renderer.render_file(filename_osstr, spec, &temp, colourer);
+    let result = renderer.render_file(filename_osstr, spec, &tiles, colourer);
     let time3 = SystemTime::now();
     if false {
         println!(

--- a/ui/src-tauri/src/save_image.rs
+++ b/ui/src-tauri/src/save_image.rs
@@ -4,7 +4,7 @@
 use anyhow::Context;
 use brot3_engine::{
     colouring,
-    fractal::{SplitMethod, Tile, TileSpec},
+    fractal::{Tile, TileSpec},
     render::{self, autodetect_extension, Renderer},
 };
 use rayon::prelude::*; // par_iter_mut
@@ -116,7 +116,7 @@ fn do_save_inner(
     let render_selection: render::Selection =
         *autodetect_extension(filename_osstr).context("Unknown file extension")?;
     let renderer = render::factory(render_selection);
-    let splits = tile.split(SplitMethod::RowsOfHeight(5), 0)?;
+    let splits = tile.split(5, 0)?;
     let mut tiles: Vec<Tile> = splits.iter().map(|ts| Tile::new(ts, 0)).collect();
     let time1 = SystemTime::now();
     tiles.par_iter_mut().for_each(|t| t.plot());

--- a/ui/src-tauri/src/save_image.rs
+++ b/ui/src-tauri/src/save_image.rs
@@ -122,7 +122,7 @@ fn do_save_inner(
     tiles.par_iter_mut().for_each(|t| t.plot());
     // SOMEDAY: Consider progress reporting
     let time2 = SystemTime::now();
-    let plot = Tile::join(tile, &tiles)?;
+    let plot = Tile::join(tile, &mut tiles)?;
     let result = renderer.render_file(filename_osstr, &plot, colourer);
     let time3 = SystemTime::now();
     if false {


### PR DESCRIPTION
*  Refactor away the complex parts of split and join, only split by strips.
* Replace array2d with a more efficient flat array.
* **Key insight: We don't actually need to `join()`**, that results in a bulky double-handling. Instead keep the strips separate until as late as possible.
* Parallelise prep and PNG render across the splits.