### PR TITLE
Enable OSD navigator, add a menu option to hide it.

### DIFF
--- a/ui/src-tauri/src/menu.rs
+++ b/ui/src-tauri/src/menu.rs
@@ -52,6 +52,8 @@ impl ApplicationMenu {
             .accelerator(format!("{cmd_or_ctrl}+G"));
         let toggle_origin_centre =
             CustomMenuItem::new("toggle_origin_centre".to_string(), "Toggle Origin/Centre");
+        let toggle_navigator =
+            CustomMenuItem::new("toggle_navigator".to_string(), "Show/Hide Navigator");
         let save_image = CustomMenuItem::new("save_image".to_string(), "Save image...")
             .accelerator(format!("{cmd_or_ctrl}+S"));
         let save_size = CustomMenuItem::new("save_size".to_string(), "Save at size...");
@@ -142,9 +144,10 @@ impl ApplicationMenu {
         menu.add_submenu(Submenu::new(
             "Display",
             Menu::new()
+                .add_item(toggle_navigator)
+                .add_native_item(MenuItem::Separator)
                 .add_item(toggle_position)
                 .add_item(go_to_position)
-                .add_native_item(MenuItem::Separator)
                 .add_item(toggle_origin_centre),
         ))
         .add_submenu(fractals)

--- a/ui/src/menu.ts
+++ b/ui/src/menu.ts
@@ -77,6 +77,9 @@ export class Menu {
                 case "fractal":
                     this.viewer.set_algorithm(event.payload.detail);
                     break;
+                case "toggle_navigator":
+                    this.viewer.toggle_navigator();
+                    break;
                 default:
                     console.error(`unknown display_message detail ${event.payload.what}`);
             }

--- a/ui/src/viewer.ts
+++ b/ui/src/viewer.ts
@@ -41,7 +41,8 @@ export class Viewer {
       visibilityRatio: 1.0,
       debugMode: false,
       showRotationControl: false,
-      showNavigator: false,
+      showNavigator: true,
+      navigatorAutoFade: true,
       showFullPageControl: false,
       zoomPerSecond: 2.0,
       toolbar: "topbar",
@@ -388,6 +389,16 @@ export class Viewer {
         });
       }
     });
+  }
+
+  private nav_visible: boolean = true;;
+  toggle_navigator() {
+    let element = this.osd.navigator.element;
+    if (this.nav_visible)
+      element.style.display = "none";
+    else
+      element.style.display = "inline-block";
+    this.nav_visible = !this.nav_visible;
   }
 
   // dummy function to shut up a linter warning in main.ts


### PR DESCRIPTION
It's not terribly useful when in a deep zoom, though.